### PR TITLE
Pass stop and clearRect to snap function

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "easy-ts-camera",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "A package which helps with adding camera support to a web application with typescript support",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/Camera.ts
+++ b/src/Camera.ts
@@ -74,6 +74,7 @@ export default class Camera {
             }
         });
     }
+
     public stop() {
         if (!this.builder.video && !this.builder.video.srcObject) return;
         if (this.builder.video.srcObject instanceof MediaStream) {
@@ -85,6 +86,7 @@ export default class Camera {
         }
         this.builder.video.srcObject = null;
     }
+
     public switchAsync(tryAgain = false): Promise<void> {
         return new Promise<void>(async (resolve, reject) => {
             this.builder.mediaConstraints.video.switchFacingMode(tryAgain);

--- a/src/Camera.ts
+++ b/src/Camera.ts
@@ -44,13 +44,13 @@ export default class Camera {
         return this.builder.canvas;
     }
 
-    snapAsDataUrl(): string {
-        this.snap();
+    snapAsDataUrl(stop: boolean = true, clearRect: boolean = true): string {
+        this.snap(stop, clearRect);
         return this.builder.canvas.toDataURL('image/png');
     }
 
-    snapAsBlobAsync(): Promise<Blob> {
-        this.snap();
+    snapAsBlobAsync(stop: boolean = true, clearRect: boolean = true): Promise<Blob> {
+        this.snap(stop, clearRect);
         return new Promise((resolve) => {
             this.builder.canvas.toBlob((blob) => {
                 resolve(blob);


### PR DESCRIPTION
I want to to call `snapAsBlobAsync` or `snapAsDataUrl` without stopping the camera. While we're at it, some people might find it useful to not clear the rectangle when calling these functions as well. Thus, these parameters have been added to the respective functions. This does not break existing code and makes more use cases possible.

(Also, some newlines have been added)